### PR TITLE
306 catalogue pages need be updated to use entercoursemodule

### DIFF
--- a/resources/webcourses/src/app/pages/catalogue/course/course.component.html
+++ b/resources/webcourses/src/app/pages/catalogue/course/course.component.html
@@ -26,7 +26,7 @@
                     Joined {{ course.user_progress.created_at | date: 'longDate' }}
                   </div>
 
-                  <wngx-enter-course [course]="course"></wngx-enter-course>
+                  <wngx-enter-course [course]="course" [btnSize]="'wide'" ></wngx-enter-course>
 
                   <div class="my-2">
                     <small class="text-secondary">

--- a/resources/webcourses/src/app/pages/catalogue/course/course.component.html
+++ b/resources/webcourses/src/app/pages/catalogue/course/course.component.html
@@ -26,7 +26,7 @@
                     Joined {{ course.user_progress.created_at | date: 'longDate' }}
                   </div>
 
-                  <wngx-enter-course [cid]="course.user_progress.selected_aid"></wngx-enter-course>
+                  <wngx-enter-course [course]="course"></wngx-enter-course>
 
                   <div class="my-2">
                     <small class="text-secondary">

--- a/resources/webcourses/src/app/pages/catalogue/course/course.module.ts
+++ b/resources/webcourses/src/app/pages/catalogue/course/course.module.ts
@@ -5,7 +5,7 @@ import { CourseRoutingModule } from './course-routing.module'
 import { LoadingSpinnerModule } from '../../../core/modules/loading-spinner/loading-spinner.module'
 import { ThemeModule } from '../../../views/theme/theme.module'
 import { StripeCheckoutModule } from 'src/app/commerce/stripe/stripe-checkout/stripe-checkout.module'
-import { EnterCourseModule } from '../../components/buttons/enter-course/enter-course.module'
+import { EnterCourseButtonModule } from '../../components/buttons/enter-course/enter-course-button.module'
 
 @NgModule({
   declarations: [CourseComponent],
@@ -15,7 +15,7 @@ import { EnterCourseModule } from '../../components/buttons/enter-course/enter-c
     LoadingSpinnerModule,
     ThemeModule,
     StripeCheckoutModule,
-    EnterCourseModule
+    EnterCourseButtonModule
   ]
 })
 

--- a/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course-button.module.ts
+++ b/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course-button.module.ts
@@ -16,4 +16,4 @@ import { EnterCourseComponent } from './enter-course.component'
   ],
   exports: [EnterCourseComponent]
 })
-export class EnterCourseModule { }
+export class EnterCourseButtonModule { }

--- a/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.html
+++ b/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.html
@@ -1,4 +1,4 @@
-<div [routerLink]="['/webcourse', 'activities', course.user_progress.id]" class="my-1">
+<div [routerLink]="['/webcourse', 'activities', course?.user_progress.selected_aid]" class="my-1">
   <button [ngClass]="btnSize" color="primary" mat-raised-button *ngIf="this.buttonStyle == 'raised'">{{ buttonName() }}</button>
   <button [ngClass]="btnSize" color="primary" mat-button class="border" *ngIf="this.buttonStyle == 'flat'">{{ buttonName() }}</button>
 </div>

--- a/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.html
+++ b/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.html
@@ -1,3 +1,5 @@
 <div [routerLink]="['/webcourse', 'activities', course.user_progress.id]" class="my-1">
   <button mat-raised-button color="primary">Enter</button>
+  <button mat-button color="primary" class="border">Resume</button>
+  <button mat-raised-button color="primary">Start</button>
 </div>

--- a/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.html
+++ b/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.html
@@ -1,4 +1,4 @@
 <div [routerLink]="['/webcourse', 'activities', course.user_progress.id]" class="my-1">
-  <button mat-raised-button color="primary" *ngIf="this.buttonStyle == 'raised'">{{this.buttonToDisplay}}</button>
-  <button mat-button color="primary" class="border" *ngIf="this.buttonStyle == 'flat'">{{this.buttonToDisplay}}</button>
+  <button [ngClass]="btnSize" color="primary" mat-raised-button *ngIf="this.buttonStyle == 'raised'">{{this.buttonToDisplay}}</button>
+  <button [ngClass]="btnSize" color="primary" mat-button class="border" *ngIf="this.buttonStyle == 'flat'">{{this.buttonToDisplay}}</button>
 </div>

--- a/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.html
+++ b/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.html
@@ -1,15 +1,3 @@
 <div [routerLink]="['/webcourse', 'activities', course.user_progress.id]" class="my-1">
-  <ng-container *ngTemplateOutlet="enterButton"></ng-container>
+  <button mat-raised-button color="primary">{{this.buttonToDisplay}}</button>
 </div>
-
-<ng-template #enterButton>
-  <button mat-raised-button color="primary">Enter</button>
-</ng-template>
-
-<ng-template #resumeButton>
-  <button mat-button color="primary" class="border">Resume</button>
-</ng-template>
-
-<ng-template #startButton>
-  <button mat-raised-button color="primary">Start</button>
-</ng-template>

--- a/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.html
+++ b/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.html
@@ -1,4 +1,4 @@
 <div [routerLink]="['/webcourse', 'activities', course.user_progress.id]" class="my-1">
   <button mat-raised-button color="primary" *ngIf="this.buttonStyle == 'raised'">{{this.buttonToDisplay}}</button>
-  <button mat-button color="primary" *ngIf="this.buttonStyle == 'flat'">{{this.buttonToDisplay}}</button>
+  <button mat-button color="primary" class="border" *ngIf="this.buttonStyle == 'flat'">{{this.buttonToDisplay}}</button>
 </div>

--- a/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.html
+++ b/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.html
@@ -1,5 +1,15 @@
 <div [routerLink]="['/webcourse', 'activities', course.user_progress.id]" class="my-1">
-  <button mat-raised-button color="primary">Enter</button>
-  <button mat-button color="primary" class="border">Resume</button>
-  <button mat-raised-button color="primary">Start</button>
+  <ng-container *ngTemplateOutlet="enterButton"></ng-container>
 </div>
+
+<ng-template #enterButton>
+  <button mat-raised-button color="primary">Enter</button>
+</ng-template>
+
+<ng-template #resumeButton>
+  <button mat-button color="primary" class="border">Resume</button>
+</ng-template>
+
+<ng-template #startButton>
+  <button mat-raised-button color="primary">Start</button>
+</ng-template>

--- a/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.html
+++ b/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.html
@@ -1,4 +1,4 @@
 <div [routerLink]="['/webcourse', 'activities', course.user_progress.id]" class="my-1">
-  <button [ngClass]="btnSize" color="primary" mat-raised-button *ngIf="this.buttonStyle == 'raised'">{{this.buttonToDisplay}}</button>
-  <button [ngClass]="btnSize" color="primary" mat-button class="border" *ngIf="this.buttonStyle == 'flat'">{{this.buttonToDisplay}}</button>
+  <button [ngClass]="btnSize" color="primary" mat-raised-button *ngIf="this.buttonStyle == 'raised'">{{ displayedButton() }}</button>
+  <button [ngClass]="btnSize" color="primary" mat-button class="border" *ngIf="this.buttonStyle == 'flat'">{{ displayedButton() }}</button>
 </div>

--- a/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.html
+++ b/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.html
@@ -1,4 +1,4 @@
 <div [routerLink]="['/webcourse', 'activities', course.user_progress.id]" class="my-1">
-  <button [ngClass]="btnSize" color="primary" mat-raised-button *ngIf="this.buttonStyle == 'raised'">{{ displayedButton() }}</button>
-  <button [ngClass]="btnSize" color="primary" mat-button class="border" *ngIf="this.buttonStyle == 'flat'">{{ displayedButton() }}</button>
+  <button [ngClass]="btnSize" color="primary" mat-raised-button *ngIf="this.buttonStyle == 'raised'">{{ buttonName() }}</button>
+  <button [ngClass]="btnSize" color="primary" mat-button class="border" *ngIf="this.buttonStyle == 'flat'">{{ buttonName() }}</button>
 </div>

--- a/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.html
+++ b/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.html
@@ -1,3 +1,4 @@
 <div [routerLink]="['/webcourse', 'activities', course.user_progress.id]" class="my-1">
-  <button mat-raised-button color="primary">{{this.buttonToDisplay}}</button>
+  <button mat-raised-button color="primary" *ngIf="this.buttonStyle == 'raised'">{{this.buttonToDisplay}}</button>
+  <button mat-button color="primary" *ngIf="this.buttonStyle == 'flat'">{{this.buttonToDisplay}}</button>
 </div>

--- a/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.html
+++ b/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.html
@@ -1,3 +1,3 @@
-<div [routerLink]="['/webcourse', 'activities', cid]" class="my-1">
+<div [routerLink]="['/webcourse', 'activities', course.user_progress.id]" class="my-1">
   <button mat-raised-button color="primary">Enter</button>
 </div>

--- a/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.scss
+++ b/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.scss
@@ -1,0 +1,3 @@
+.wide {
+  width: 15rem;
+}

--- a/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.ts
+++ b/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.ts
@@ -10,7 +10,7 @@ export class EnterCourseComponent {
   @Input() buttonStyle: string = 'raised'
   @Input() public btnSize: string
 
-  displayedButton() {
+  buttonName() {
     if (this.course.user_progress.total_activities_completed === 0) {
       return 'Start'
     } else if (this.course.user_progress.total_activities_completed === this.course.total_activities) {

--- a/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.ts
+++ b/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.ts
@@ -6,6 +6,6 @@ import { Component, Input } from '@angular/core'
   styleUrls: ['./enter-course.component.scss']
 })
 export class EnterCourseComponent {
-  @Input() cid: number
+  @Input() course: any
 
 }

--- a/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.ts
+++ b/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.ts
@@ -7,6 +7,7 @@ import { Component, Input, OnInit } from '@angular/core'
 })
 export class EnterCourseComponent implements OnInit {
   @Input() course: any
+  @Input() buttonStyle: string = 'raised'
   buttonToDisplay: 'Start' | 'Enter' | 'Resume'
 
   ngOnInit() {

--- a/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.ts
+++ b/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.ts
@@ -1,11 +1,25 @@
-import { Component, Input } from '@angular/core'
+import { Component, Input, OnInit } from '@angular/core'
 
 @Component({
   selector: 'wngx-enter-course',
   templateUrl: './enter-course.component.html',
   styleUrls: ['./enter-course.component.scss']
 })
-export class EnterCourseComponent {
+export class EnterCourseComponent implements OnInit {
   @Input() course: any
+  buttonToDisplay: 'Start' | 'Enter' | 'Resume'
 
+  ngOnInit() {
+    this.displayedButton()
+  }
+
+  displayedButton() {
+    if (this.course.user_progress.total_activities_completed === 0) {
+      this.buttonToDisplay = 'Start'
+    } else if (this.course.user_progress.total_activities_completed === this.course.total_activities) {
+      this.buttonToDisplay = 'Enter'
+    } else {
+      this.buttonToDisplay = 'Resume'
+    }
+  }
 }

--- a/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.ts
+++ b/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.ts
@@ -8,7 +8,7 @@ import { Component, Input, OnInit } from '@angular/core'
 export class EnterCourseComponent implements OnInit {
   @Input() course: any
   @Input() buttonStyle: string = 'raised'
-  buttonToDisplay: 'Start' | 'Review' | 'Resume'
+  buttonToDisplay: 'Start' | 'Review' | 'Continue'
 
   ngOnInit() {
     this.displayedButton()
@@ -20,7 +20,7 @@ export class EnterCourseComponent implements OnInit {
     } else if (this.course.user_progress.total_activities_completed === this.course.total_activities) {
       this.buttonToDisplay = 'Review'
     } else {
-      this.buttonToDisplay = 'Resume'
+      this.buttonToDisplay = 'Continue'
     }
   }
 }

--- a/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.ts
+++ b/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.ts
@@ -1,28 +1,22 @@
-import { Component, Input, OnInit } from '@angular/core'
+import { Component, Input } from '@angular/core'
 
 @Component({
   selector: 'wngx-enter-course',
   templateUrl: './enter-course.component.html',
   styleUrls: ['./enter-course.component.scss']
 })
-export class EnterCourseComponent implements OnInit {
+export class EnterCourseComponent {
   @Input() course: any
   @Input() buttonStyle: string = 'raised'
   @Input() public btnSize: string
 
-  buttonToDisplay: 'Start' | 'Review' | 'Continue'
-
-  ngOnInit() {
-    this.displayedButton()
-  }
-
   displayedButton() {
     if (this.course.user_progress.total_activities_completed === 0) {
-      this.buttonToDisplay = 'Start'
+      return 'Start'
     } else if (this.course.user_progress.total_activities_completed === this.course.total_activities) {
-      this.buttonToDisplay = 'Review'
+      return 'Review'
     } else {
-      this.buttonToDisplay = 'Continue'
+      return 'Continue'
     }
   }
 }

--- a/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.ts
+++ b/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.ts
@@ -8,7 +8,7 @@ import { Component, Input, OnInit } from '@angular/core'
 export class EnterCourseComponent implements OnInit {
   @Input() course: any
   @Input() buttonStyle: string = 'raised'
-  buttonToDisplay: 'Start' | 'Enter' | 'Resume'
+  buttonToDisplay: 'Start' | 'Review' | 'Resume'
 
   ngOnInit() {
     this.displayedButton()
@@ -18,7 +18,7 @@ export class EnterCourseComponent implements OnInit {
     if (this.course.user_progress.total_activities_completed === 0) {
       this.buttonToDisplay = 'Start'
     } else if (this.course.user_progress.total_activities_completed === this.course.total_activities) {
-      this.buttonToDisplay = 'Enter'
+      this.buttonToDisplay = 'Review'
     } else {
       this.buttonToDisplay = 'Resume'
     }

--- a/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.ts
+++ b/resources/webcourses/src/app/pages/components/buttons/enter-course/enter-course.component.ts
@@ -8,6 +8,8 @@ import { Component, Input, OnInit } from '@angular/core'
 export class EnterCourseComponent implements OnInit {
   @Input() course: any
   @Input() buttonStyle: string = 'raised'
+  @Input() public btnSize: string
+
   buttonToDisplay: 'Start' | 'Review' | 'Continue'
 
   ngOnInit() {

--- a/resources/webcourses/src/app/pages/components/course-card/catalogue-card/catalogue-card.component.html
+++ b/resources/webcourses/src/app/pages/components/course-card/catalogue-card/catalogue-card.component.html
@@ -37,14 +37,9 @@
       *ngIf="course?.user_progress == null; else courseUnlocked"
     ></app-stripe-checkout>
 
-    <!-- RESUME Button -->
+    <!-- Enter Button -->
     <ng-template #courseUnlocked>
-      <button
-        mat-button
-        color="primary"
-        class="border"
-        [routerLink]="['/webcourse', 'activities', course?.user_progress.selected_aid]"
-      >Resume</button>
+    <wngx-enter-course [course]="course" [buttonStyle]="'flat'"></wngx-enter-course>
     </ng-template>
 
     <!-- ABOUT Button -->

--- a/resources/webcourses/src/app/pages/components/course-card/catalogue-card/catalogue-card.component.html
+++ b/resources/webcourses/src/app/pages/components/course-card/catalogue-card/catalogue-card.component.html
@@ -30,7 +30,7 @@
     <span class="text-dark" [innerHtml]="course.short_desc | safehtml: 'html'"></span>
   </mat-card-content>
 
-  <mat-card-actions [ngClass]="'px-2'">
+  <mat-card-actions [ngClass]="'px-2 d-inline-flex'">
     <!-- BUY Button -->
     <app-stripe-checkout
       [cid]="course.id"

--- a/resources/webcourses/src/app/pages/components/course-card/catalogue-card/catalogue-card.module.ts
+++ b/resources/webcourses/src/app/pages/components/course-card/catalogue-card/catalogue-card.module.ts
@@ -8,6 +8,7 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome'
 import { CatalogueCardComponent } from './catalogue-card.component'
 import { StripeCheckoutModule } from 'src/app/commerce/stripe/stripe-checkout/stripe-checkout.module'
 import { PipesModule } from './../../../../shared/pipes/pipes.module'
+import { EnterCourseModule } from '../../buttons/enter-course/enter-course.module'
 
 @NgModule({
   declarations: [CatalogueCardComponent],
@@ -18,7 +19,8 @@ import { PipesModule } from './../../../../shared/pipes/pipes.module'
     MatButtonModule,
     FontAwesomeModule,
     PipesModule,
-    StripeCheckoutModule
+    StripeCheckoutModule,
+    EnterCourseModule
   ],
   exports: [CatalogueCardComponent]
 })

--- a/resources/webcourses/src/app/pages/components/course-card/catalogue-card/catalogue-card.module.ts
+++ b/resources/webcourses/src/app/pages/components/course-card/catalogue-card/catalogue-card.module.ts
@@ -8,7 +8,7 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome'
 import { CatalogueCardComponent } from './catalogue-card.component'
 import { StripeCheckoutModule } from 'src/app/commerce/stripe/stripe-checkout/stripe-checkout.module'
 import { PipesModule } from './../../../../shared/pipes/pipes.module'
-import { EnterCourseModule } from '../../buttons/enter-course/enter-course.module'
+import { EnterCourseButtonModule } from '../../buttons/enter-course/enter-course-button.module'
 
 @NgModule({
   declarations: [CatalogueCardComponent],
@@ -20,7 +20,7 @@ import { EnterCourseModule } from '../../buttons/enter-course/enter-course.modul
     FontAwesomeModule,
     PipesModule,
     StripeCheckoutModule,
-    EnterCourseModule
+    EnterCourseButtonModule
   ],
   exports: [CatalogueCardComponent]
 })

--- a/resources/webcourses/src/app/pages/user/webcourses/webcourses.component.html
+++ b/resources/webcourses/src/app/pages/user/webcourses/webcourses.component.html
@@ -56,12 +56,10 @@
                   <div class="card-title text-dark">{{ userSelectedCourse.title }}</div>
                 </div>
                 <div class="col-auto">
-                  <button
-                    mat-button color="primary" class="border my-3"
-                    (click)="enterButton(userSelectedCourse.user_progress.selected_aid)"
-                  >
-                    Resume
-                  </button>
+                  <div class="my-3 d-inline-flex">
+                    <wngx-enter-course [course]="userSelectedCourse" [buttonStyle]="'flat'"></wngx-enter-course>
+                  </div>
+
                   <button
                     mat-button color="primary" class="my-3 mx-1"
                     [routerLink]="['/catalogue', 'course', userSelectedCourse.id]"

--- a/resources/webcourses/src/app/pages/user/webcourses/webcourses.component.html
+++ b/resources/webcourses/src/app/pages/user/webcourses/webcourses.component.html
@@ -56,6 +56,8 @@
                   <div class="card-title text-dark">{{ userSelectedCourse.title }}</div>
                 </div>
                 <div class="col-auto">
+
+                  <!-- Enter course button -->
                   <div class="my-3 d-inline-flex">
                     <wngx-enter-course [course]="userSelectedCourse" [buttonStyle]="'flat'"></wngx-enter-course>
                   </div>
@@ -137,12 +139,12 @@
               <div class="text-dark">
                 Joined: {{ course.user_progress.created_at | date:'longDate' }}
               </div>
-              <button
-                mat-button color="primary" class="border my-3"
-                (click)="enterButton(course.user_progress.selected_aid)"
-              >
-                Enter
-              </button>
+
+              <!-- Enter course button -->
+              <div class="my-3 d-inline-flex">
+              <wngx-enter-course [course]="course" [buttonStyle]="'flat'"></wngx-enter-course>
+              </div>
+
               <button
                 mat-button color="primary" class="mt-3 ml-2"
                 [routerLink]="['/catalogue', 'course', course.id]"

--- a/resources/webcourses/src/app/pages/user/webcourses/webcourses.module.ts
+++ b/resources/webcourses/src/app/pages/user/webcourses/webcourses.module.ts
@@ -9,7 +9,7 @@ import { WebcoursesComponent } from './webcourses.component'
 import { WebcoursesRoutingModule } from './webcourses-routing.module'
 import { CatalogueCardModule } from '../../components/course-card/catalogue-card/catalogue-card.module'
 import { LoadingSpinnerModule } from '../../../core/modules/loading-spinner/loading-spinner.module'
-import { EnterCourseModule } from '../../components/buttons/enter-course/enter-course.module'
+import { EnterCourseButtonModule } from '../../components/buttons/enter-course/enter-course-button.module'
 
 @NgModule({
   declarations: [
@@ -24,7 +24,7 @@ import { EnterCourseModule } from '../../components/buttons/enter-course/enter-c
     CatalogueCardModule,
     LoadingSpinnerModule,
     FontAwesomeModule,
-    EnterCourseModule
+    EnterCourseButtonModule
   ]
 })
 

--- a/resources/webcourses/src/app/pages/user/webcourses/webcourses.module.ts
+++ b/resources/webcourses/src/app/pages/user/webcourses/webcourses.module.ts
@@ -9,6 +9,7 @@ import { WebcoursesComponent } from './webcourses.component'
 import { WebcoursesRoutingModule } from './webcourses-routing.module'
 import { CatalogueCardModule } from '../../components/course-card/catalogue-card/catalogue-card.module'
 import { LoadingSpinnerModule } from '../../../core/modules/loading-spinner/loading-spinner.module'
+import { EnterCourseModule } from '../../components/buttons/enter-course/enter-course.module'
 
 @NgModule({
   declarations: [
@@ -22,7 +23,8 @@ import { LoadingSpinnerModule } from '../../../core/modules/loading-spinner/load
     WebcoursesRoutingModule,
     CatalogueCardModule,
     LoadingSpinnerModule,
-    FontAwesomeModule
+    FontAwesomeModule,
+    EnterCourseModule
   ]
 })
 


### PR DESCRIPTION
A few notes to sooth potential headaches. I initially chose to pass the whole course object instead of the cid as we need three values when deciding what button to show.
commit: https://github.com/eclectic-bytech/webcourses-ngx-v4/commit/11b66e48250f58c44282df683c88a358261aec9d

I decided just to change the text inside of the button instead of using ngif when deciding what button to show.
commit: https://github.com/eclectic-bytech/webcourses-ngx-v4/commit/dca83124380adb1a33deaebb764bf54d626e15d3

When changing Enter to Review I decided to change Resume to Continue. I did this because the options would have been resume review and start. so you can see how the first two may have started to blend together.
 
Finally I had to pass what kind of button we wanted on each page. I don't know if you thought of this initially but we need two versions of each button type. this is because they are meant to look different on the catalogue page as opposed to the about page